### PR TITLE
Bulk insert queries

### DIFF
--- a/src/Actions/SeedAction.php
+++ b/src/Actions/SeedAction.php
@@ -295,10 +295,9 @@ class SeedAction extends Seeder
 	 */
 	private function seedLanguages(): void
 	{
-		// languages
-		foreach ($this->modules['languages']['data'] as $language) {
-			Models\Language::create($language);
-		}
+        // languages
+        Models\Language::query()
+            ->insert($this->modules['languages']['data']);
 	}
 
 	/**

--- a/src/Actions/SeedAction.php
+++ b/src/Actions/SeedAction.php
@@ -253,13 +253,17 @@ class SeedAction extends Seeder
 	 */
 	private function seedTimezones(Models\Country $country, $countryArray): void
 	{
+	    $bulk_timezones = [];
+
 		foreach ($countryArray['timezones'] as $timezone) {
-			$country
-				->timezones()
-				->create([
-					'name' => (string) $timezone['zoneName'],
-				]);
+		    $bulk_timezones[] = [
+		        'country_id' => $country->id,
+                'name' => (string) $timezone['zoneName']
+            ];
 		}
+
+		Models\Timezone::query()
+            ->insert($bulk_timezones);
 	}
 
 	private function seedCurrencies(Models\Country $country, array $countryArray): void


### PR DESCRIPTION
Based on issue #54 I changed the seeder private class to insert bulk queries instead of running a single query in a for-each loop. With these changes on my localhost setup, the seed actions take about 3 minutes to complete.