### PR TITLE
fix for length of state_code

### DIFF
--- a/config/world.php
+++ b/config/world.php
@@ -122,7 +122,7 @@ return [
 				'state_code' => [
 					'required' => false,
 					'type' => 'string',
-					'length' => 3,
+					'length' => 5,
 				],
 				'latitude' => [
 					'required' => false,
@@ -145,7 +145,7 @@ return [
 				'state_code' => [
 					'required' => false,
 					'type' => 'string',
-					'length' => 3,
+					'length' => 5,
 				],
 				'latitude' => [
 					'required' => false,


### PR DESCRIPTION
When state_code is required in config/world.php it results in a seeding error

> SQLSTATE[22001]: String data, right truncated: 1406 Data too long for column 'state_code'


state_code contains data like 'SH-HL', 'UM-81' and 'CDMX' which require a length of 5