### PR TITLE
Feature run migrations based on config

### DIFF
--- a/src/Commands/RefreshWorldData.php
+++ b/src/Commands/RefreshWorldData.php
@@ -49,13 +49,29 @@ class RefreshWorldData extends Command
 		// drop the world tables
 		$worldTables = [
 			'world.migrations.countries.table_name',
-			'world.migrations.states.table_name',
-			'world.migrations.cities.table_name',
-			'world.migrations.timezones.table_name',
-			'world.migrations.currencies.table_name',
-			'world.migrations.languages.table_name',
 		];
-		// drop a table if it exists
+
+        if (config('world.modules.states', true)) {
+            $worldTables[] = 'world.migrations.states.table_name';
+        }
+
+        if (config('world.modules.cities', true)) {
+            $worldTables[] = 'world.migrations.cities.table_name';
+        }
+
+        if (config('world.modules.timezones', true)) {
+            $worldTables[] = 'world.migrations.timezones.table_name';
+        }
+
+        if (config('world.modules.currencies', true)) {
+            $worldTables[] = 'world.migrations.currencies.table_name';
+        }
+
+        if (config('world.modules.languages', true)) {
+            $worldTables[] = 'world.migrations.languages.table_name';
+        }
+
+        // drop a table if it exists
 		foreach ($worldTables as $worldTable) {
 			Schema::dropIfExists(config($worldTable));
 		}

--- a/src/Database/Migrations/2020_07_07_055725_create_cities_table.php
+++ b/src/Database/Migrations/2020_07_07_055725_create_cities_table.php
@@ -13,18 +13,20 @@ class CreateCitiesTable extends Migration
 	 */
 	public function up()
 	{
-		Schema::create(config('world.migrations.cities.table_name'), function (Blueprint $table) {
-			$table->id();
-			$table->foreignId('country_id');
-			$table->foreignId('state_id');
-			$table->string('name');
+		if(config('world.modules.cities')){
+			Schema::create(config('world.migrations.cities.table_name'), function (Blueprint $table) {
+				$table->id();
+				$table->foreignId('country_id');
+				$table->foreignId('state_id');
+				$table->string('name');
 
-			foreach (config('world.migrations.cities.optional_fields') as $field => $value) {
-				if ($value['required']) {
-					$table->string($field, $value['length'] ?? null);
+				foreach (config('world.migrations.cities.optional_fields') as $field => $value) {
+					if ($value['required']) {
+						$table->string($field, $value['length'] ?? null);
+					}
 				}
-			}
-		});
+			});
+		}
 	}
 
 	/**
@@ -34,6 +36,8 @@ class CreateCitiesTable extends Migration
 	 */
 	public function down()
 	{
-		Schema::dropIfExists(config('world.migrations.cities.table_name'));
+		if(config('world.modules.cities')){
+			Schema::dropIfExists(config('world.migrations.cities.table_name'));
+		}
 	}
 }

--- a/src/Database/Migrations/2020_07_07_055746_create_timezones_table.php
+++ b/src/Database/Migrations/2020_07_07_055746_create_timezones_table.php
@@ -13,11 +13,13 @@ class CreateTimezonesTable extends Migration
 	 */
 	public function up()
 	{
-		Schema::create(config('world.migrations.timezones.table_name'), function (Blueprint $table) {
-			$table->id();
-			$table->foreignId('country_id');
-			$table->string('name');
-		});
+		if(config('world.modules.timezones')){
+			Schema::create(config('world.migrations.timezones.table_name'), function (Blueprint $table) {
+				$table->id();
+				$table->foreignId('country_id');
+				$table->string('name');
+			});
+		}
 	}
 
 	/**
@@ -27,6 +29,8 @@ class CreateTimezonesTable extends Migration
 	 */
 	public function down()
 	{
-		Schema::dropIfExists(config('world.migrations.timezones.table_name'));
+		if(config('world.modules.timezones')){
+			Schema::dropIfExists(config('world.migrations.timezones.table_name'));
+		}
 	}
 }

--- a/src/Database/Migrations/2021_10_19_071730_create_states_table.php
+++ b/src/Database/Migrations/2021_10_19_071730_create_states_table.php
@@ -13,17 +13,19 @@ class CreateStatesTable extends Migration
 	 */
 	public function up()
 	{
-		Schema::create(config('world.migrations.states.table_name'), function (Blueprint $table) {
-			$table->id();
-			$table->foreignId('country_id');
-			$table->string('name');
+		if(config('world.modules.states')){
+			Schema::create(config('world.migrations.states.table_name'), function (Blueprint $table) {
+				$table->id();
+				$table->foreignId('country_id');
+				$table->string('name');
 
-			foreach (config('world.migrations.states.optional_fields') as $field => $value) {
-				if ($value['required']) {
-					$table->string($field, $value['length'] ?? null);
+				foreach (config('world.migrations.states.optional_fields') as $field => $value) {
+					if ($value['required']) {
+						$table->string($field, $value['length'] ?? null);
+					}
 				}
-			}
-		});
+			});
+		}
 	}
 
 	/**
@@ -33,6 +35,8 @@ class CreateStatesTable extends Migration
 	 */
 	public function down()
 	{
-		Schema::dropIfExists(config('world.migrations.states.table_name'));
+		if(config('world.modules.states')){
+			Schema::dropIfExists(config('world.migrations.states.table_name'));
+		}
 	}
 }

--- a/src/Database/Migrations/2021_10_23_082414_create_currencies_table.php
+++ b/src/Database/Migrations/2021_10_23_082414_create_currencies_table.php
@@ -13,18 +13,20 @@ class CreateCurrenciesTable extends Migration
 	 */
 	public function up()
 	{
-		Schema::create(config('world.migrations.currencies.table_name'), function (Blueprint $table) {
-			$table->id();
-			$table->foreignId('country_id');
-			$table->string('name');
-			$table->string('code');
-			$table->tinyInteger('precision')->default(2);
-			$table->string('symbol');
-			$table->string('symbol_native');
-			$table->tinyInteger('symbol_first')->default(1);
-			$table->string('decimal_mark', 1)->default('.');
-			$table->string('thousands_separator', 1)->default(',');
-		});
+		if(config('world.modules.currencies')){
+			Schema::create(config('world.migrations.currencies.table_name'), function (Blueprint $table) {
+				$table->id();
+				$table->foreignId('country_id');
+				$table->string('name');
+				$table->string('code');
+				$table->tinyInteger('precision')->default(2);
+				$table->string('symbol');
+				$table->string('symbol_native');
+				$table->tinyInteger('symbol_first')->default(1);
+				$table->string('decimal_mark', 1)->default('.');
+				$table->string('thousands_separator', 1)->default(',');
+			});
+		}
 	}
 
 	/**
@@ -34,6 +36,8 @@ class CreateCurrenciesTable extends Migration
 	 */
 	public function down()
 	{
-		Schema::dropIfExists(config('world.migrations.currencies.table_name'));
+		if(config('world.modules.currencies')){
+			Schema::dropIfExists(config('world.migrations.currencies.table_name'));
+		}
 	}
 }

--- a/src/Database/Migrations/2022_01_22_034939_create_languages_table.php
+++ b/src/Database/Migrations/2022_01_22_034939_create_languages_table.php
@@ -13,13 +13,16 @@ class CreateLanguagesTable extends Migration
 	 */
 	public function up()
 	{
-		Schema::create(config('world.migrations.languages.table_name'), function (Blueprint $table) {
-			$table->id();
-			$table->char('code', 2);
-			$table->string('name');
-			$table->string('name_native');
-			$table->char('dir', 3);
-		});
+        if(config('world.modules.languages')){
+            Schema::create(config('world.migrations.languages.table_name'), function (Blueprint $table) {
+                $table->id();
+                $table->char('code', 2);
+                $table->string('name');
+                $table->string('name_native');
+                $table->char('dir', 3);
+            });
+        }
+
 	}
 
 	/**
@@ -29,6 +32,8 @@ class CreateLanguagesTable extends Migration
 	 */
 	public function down()
 	{
-		Schema::dropIfExists(config('world.migrations.languages.table_name'));
+        if(config('world.modules.languages')) {
+            Schema::dropIfExists(config('world.migrations.languages.table_name'));
+        }
 	}
 }


### PR DESCRIPTION
These changes check the config for enabled modules before running the migration.

When using this project, I noticed a table would be created despite a module being disabled. This may not be the most elegant solution, but it prevents the migration from running when the module is disabled.


```
//Database/Migrations/2022_01_22_034939_create_languages_table.php
        if(config('world.modules.languages')){
            Schema::create(config('world.migrations.languages.table_name'), function (Blueprint $table) {
                $table->id();
                $table->char('code', 2);
                $table->string('name');
                $table->string('name_native');
                $table->char('dir', 3);
            });
        }
```