### PR TITLE
FIX: set turkey lira symbol

### DIFF
--- a/resources/json/currencies.json
+++ b/resources/json/currencies.json
@@ -929,7 +929,7 @@
 	"TRY": {
 		"symbol": "TL",
 		"name": "Turkish Lira",
-		"symbol_native": "TL",
+		"symbol_native": "₺",
 		"decimal_digits": 2,
 		"rounding": 0,
 		"code": "TRY",


### PR DESCRIPTION
Hi
Based on [Turkish Lira wikipedia page](https://en.wikipedia.org/wiki/Turkish_lira) the lira symbol is [₺](https://en.wikipedia.org/wiki/Turkish_lira_sign). Please check and if everything is ok confirm the pull request.