### PR TITLE
Update 2021_10_19_071730_create_states_table.php

### DIFF
--- a/src/Database/Migrations/2021_10_19_071730_create_states_table.php
+++ b/src/Database/Migrations/2021_10_19_071730_create_states_table.php
@@ -20,7 +20,7 @@ class CreateStatesTable extends Migration
 
 			foreach (config('world.migrations.states.optional_fields') as $field => $value) {
 				if ($value['required']) {
-					$table->string($field, $value['length'] ?? null);
+					$table->string($field, $value['length'] ?? null)->nullable();
 				}
 			}
 		});


### PR DESCRIPTION
Set optional columns as nullable. JSON files for states do not have all the data and seeders fail. This will fix this problem