### PR TITLE
Fixed replacement in response.php for Italian with slight form improvement

### DIFF
--- a/resources/lang/it/response.php
+++ b/resources/lang/it/response.php
@@ -3,7 +3,7 @@
 return [
 	'errors' => [
 		'server_error' => 'Errore interno del server',
-		'record_not_found' => 'No: attributo trovato!',
+		'record_not_found' => 'Nessun elemento di :attribute trovato!',
 	],
 	'attributes' => [
 		'phone' => 'telefono|telefoni',


### PR DESCRIPTION
I noticed that the `:attribute` placeholder was translated as `No: attributo` breaking the feature.

This PR fixes this bug for Italian language and uses a slightly improved sentence form.

I also noticed that other languages have this bug, so if this gets approved I will use this PR or make another one to fix them too.