### PR TITLE
Fixed :attribute for responses in the following languages: br, fr, hr, kr, pt

### DIFF
--- a/resources/lang/br/response.php
+++ b/resources/lang/br/response.php
@@ -3,7 +3,7 @@
 return [
 	'errors' => [
 		'server_error' => 'Erro do Servidor Interno',
-		'record_not_found' => 'Não :atribute foi encontrado!',
+		'record_not_found' => 'Não :attribute foi encontrado!',
 	],
 	'attributes' => [
 		'phone' => 'telefone|telefones',

--- a/resources/lang/fr/response.php
+++ b/resources/lang/fr/response.php
@@ -3,7 +3,7 @@
 return [
 	'errors' => [
 		'server_error' => 'Erreur Interne du Serveur',
-		'record_not_found' => 'Non :attribute a été trouvé !',
+		'record_not_found' => 'Non :attribute a été trouvé!',
 	],
 	'attributes' => [
 		'phone' => 'téléphone|téléphones',

--- a/resources/lang/hr/response.php
+++ b/resources/lang/hr/response.php
@@ -3,7 +3,7 @@
 return [
 	'errors' => [
 		'server_error' => 'Interna pogreška poslužitelja',
-		'record_not_found' => ':atribut nije pronađeno!',
+		'record_not_found' => ':attribute nije pronađeno!',
 	],
 	'attributes' => [
 		'phone' => 'telefon|telefoni',

--- a/resources/lang/kr/response.php
+++ b/resources/lang/kr/response.php
@@ -3,7 +3,7 @@
 return [
 	'errors' => [
 		'server_error' => '인터넷 서버 오류',
-		'record_not_found' => '아니오 attribute: 을(를) 찾았습니다!',
+		'record_not_found' => '아니오 :attribute 을(를) 찾았습니다!',
 	],
 	'attributes' => [
 		'phone' => '핸드폰|전화',

--- a/resources/lang/pt/response.php
+++ b/resources/lang/pt/response.php
@@ -3,7 +3,7 @@
 return [
 	'errors' => [
 		'server_error' => 'Erro do Servidor Interno',
-		'record_not_found' => 'Não :atribute foi encontrado!',
+		'record_not_found' => 'Não :attribute foi encontrado!',
 	],
 	'attributes' => [
 		'phone' => 'telefone|telefones',


### PR DESCRIPTION
As stated in #76, I noticed that the `:attribute` placeholder has been translated in some languages.

I fixed all the languages I can work with, but I don't know if `ar` needs this fix too so I skipped it.