### PR TITLE
added disabling of foreign key checks to seeder in initCountries

### DIFF
--- a/src/Actions/SeedAction.php
+++ b/src/Actions/SeedAction.php
@@ -141,7 +141,9 @@ class SeedAction extends Seeder
 	 */
 	private function initCountries(): void
 	{
+		$this->schema->disableForeignKeyConstraints();
 		app(Models\Country::class)->truncate();
+		$this->schema->enableForeignKeyConstraints();
 
 		$this->countries['data'] = json_decode(File::get(__DIR__ . '/../../resources/json/countries.json'), true);
 


### PR DESCRIPTION
Problem which is similar to #15. Solved by disabling the foreign key checks here. 

If one of the normal tables is referencing the foreign key of the countries table then the seeder will fail with the access violation error for not truncating referenced tables.