### PR TITLE
Fix BadMethodCallException by replacing app()->truncate() with ::truncate()

### DIFF
--- a/src/Actions/SeedAction.php
+++ b/src/Actions/SeedAction.php
@@ -44,7 +44,7 @@ class SeedAction extends Seeder
 	public function __construct()
 	{
 		foreach ($this->modules as $name => $data) {
-			$this->modules[$name]['class'] = config('world.models.'.$name);
+			$this->modules[$name]['class'] = config('world.models.' . $name);
 		}
 
 		$this->schema = Schema::connection(config('world.connection'));
@@ -143,7 +143,13 @@ class SeedAction extends Seeder
 	{
 		$this->schema->disableForeignKeyConstraints();
 		$countryClass = config('world.models.countries');
-		app($countryClass)->truncate();
+		
+		## Original code
+		// app($countryClass)->truncate();
+
+		## My custom code to truncate data
+		$countryClass::truncate();
+
 		$this->schema->enableForeignKeyConstraints();
 
 		$this->countries['data'] = json_decode(File::get(__DIR__ . '/../../resources/json/countries.json'), true);


### PR DESCRIPTION
**Summary of the Fix:**
This pull request fixes an issue where calling `app($countryClass)->truncate();` in the `SeedAction.php` file throws a `BadMethodCallException`. The error occurs because `truncate()` is being called on an instance of `Illuminate\Foundation\Application`, which does not have a `truncate()` method.

**Fix:**
I replaced the code `app($countryClass)->truncate();` with `$countryClass::truncate();`, which directly calls the `truncate()` method on the model class, resolving the issue.

**Reference:**
This fix addresses the issue reported in [Issue #112]