### PR TITLE
Fix Array to string conversion in countries for 'timezones' and 'translations'

### DIFF
--- a/src/Models/Country.php
+++ b/src/Models/Country.php
@@ -42,6 +42,8 @@ class Country extends Model
     {
         return [
             'status' => 'int',
+			'timezones' => 'array',
+            'translations' => 'array',
         ];
     }
 


### PR DESCRIPTION
Error insert 'timezones' and 'translations' data.

QueryExceptio: Array to string conversion - Connection: mysql, SQL: insert into `countries`