### PR TITLE
fix: update Indian Rupee symbol to use the correct native representation

### DIFF
--- a/resources/json/currencies.json
+++ b/resources/json/currencies.json
@@ -434,7 +434,7 @@
 	"INR": {
 		"symbol": "Rs",
 		"name": "Indian Rupee",
-		"symbol_native": "টকা",
+		"symbol_native": "₹",
 		"decimal_digits": 2,
 		"rounding": 0,
 		"code": "INR",


### PR DESCRIPTION
This pull request updates the native currency symbol for the Indian Rupee in the `currencies.json` resource file which provides a fix for #138 

- Currency Data Correction:
  * Updated the `symbol_native` value for `INR` from "টকা" to the correct symbol "₹" in `currencies.json`.