### PR TITLE
fix foreign key relations in migrations

### DIFF
--- a/src/Database/Migrations/2020_07_07_055725_create_cities_table.php
+++ b/src/Database/Migrations/2020_07_07_055725_create_cities_table.php
@@ -13,8 +13,8 @@ return new class extends BaseMigration
     {
         Schema::create(config('world.migrations.cities.table_name'), function (Blueprint $table) {
             $table->id();
-            $table->foreignId('country_id');
-            $table->foreignId('state_id');
+            $table->foreignId('country_id')->constrained('countries')->cascadeOnDelete()->cascadeOnUpdate();
+            $table->foreignId('state_id')->constrained('states')->cascadeOnDelete()->cascadeOnUpdate();
             $table->string('name');
 
             foreach (config('world.migrations.cities.optional_fields') as $field => $value) {

--- a/src/Database/Migrations/2020_07_07_055746_create_timezones_table.php
+++ b/src/Database/Migrations/2020_07_07_055746_create_timezones_table.php
@@ -13,7 +13,7 @@ return new class extends BaseMigration
     {
         Schema::create(config('world.migrations.timezones.table_name'), function (Blueprint $table) {
             $table->id();
-            $table->foreignId('country_id');
+            $table->foreignId('country_id')->constrained('countries')->cascadeOnDelete()->cascadeOnUpdate();
             $table->string('name');
         });
     }

--- a/src/Database/Migrations/2021_10_19_071730_create_states_table.php
+++ b/src/Database/Migrations/2021_10_19_071730_create_states_table.php
@@ -13,7 +13,7 @@ return new class extends BaseMigration
     {
         Schema::create(config('world.migrations.states.table_name'), function (Blueprint $table) {
             $table->id();
-            $table->foreignId('country_id');
+            $table->foreignId('country_id')->constrained('countries')->cascadeOnDelete()->cascadeOnUpdate();
             $table->string('name');
 
             foreach (config('world.migrations.states.optional_fields') as $field => $value) {

--- a/src/Database/Migrations/2021_10_23_082414_create_currencies_table.php
+++ b/src/Database/Migrations/2021_10_23_082414_create_currencies_table.php
@@ -13,7 +13,7 @@ return new class extends BaseMigration
 	{
 		Schema::create(config('world.migrations.currencies.table_name'), function (Blueprint $table) {
 			$table->id();
-			$table->foreignId('country_id');
+			$table->foreignId('country_id')->constrained('countries')->cascadeOnDelete()->cascadeOnUpdate();
 			$table->string('name');
 			$table->string('code');
 			$table->tinyInteger('precision')->default(2);


### PR DESCRIPTION
Fixed missing foreign key constraints in the migrations , this resolves integrity issues when running fresh migrations.